### PR TITLE
(feat): Handle sceanrios where the streaming response has ended

### DIFF
--- a/code/copilot/app/agents/root.py
+++ b/code/copilot/app/agents/root.py
@@ -155,7 +155,7 @@ class RootAgent:
                 "It was detected that the streaming response has timed out, or was cancelled. We will send the remaining response as a text message once completed."
             )
             typing_indicator.start()
-        return streaming_response_ended and previously_detected_streaming_ended
+        return streaming_response_ended or previously_detected_streaming_ended
 
     # TODO: https://cookbook.openai.com/examples/how_to_handle_rate_limits
     async def stream_response(

--- a/code/copilot/app/agents/root.py
+++ b/code/copilot/app/agents/root.py
@@ -6,6 +6,7 @@ from agents.usage import Usage
 from app.logs import setup_logging
 from azure.identity.aio import DefaultAzureCredential, get_bearer_token_provider
 from microsoft_agents.hosting.core import TurnContext
+from microsoft_agents.hosting.core.app.typing_indicator import TypingIndicator
 from openai import AsyncOpenAI
 from openai.types.responses import ResponseTextDeltaEvent
 from openai.types.shared.reasoning import Reasoning
@@ -122,6 +123,40 @@ class RootAgent:
             f"Document Agent usage. Output tokens: {usage.output_tokens}, Output token details: {usage.output_tokens_details}"
         )
 
+    @staticmethod
+    async def _check_streaming_has_ended(
+        context: TurnContext,
+        typing_indicator: TypingIndicator,
+        previously_detected_streaming_ended: bool = False,
+    ):
+        """
+        Check if the streaming response has ended.
+
+        :param context: The TurnContext for the current turn.
+        :type context: TurnContext
+        :param typing_indicator: The TypingIndicator for the current turn.
+        :type typing_indicator: TypingIndicator
+        :param previously_detected_streaming_ended: Whether streaming end was previously detected.
+        :type previously_detected_streaming_ended: bool
+        """
+        streaming_response_ended = (
+            context.streaming_response._ended or context.streaming_response._canceled
+        )
+        if streaming_response_ended and not previously_detected_streaming_ended:
+            logger.warning(
+                "The streaming response has already ended or was canceled.",
+                extra={
+                    "code": "STREAMING_RESPONSE_ENDED_OR_CANCELED",
+                    "streaming_response_ended": context.streaming_response._ended,
+                    "streaming_response_canceled": context.streaming_response._canceled,
+                },
+            )
+            await context.send_activity(
+                "It was detected that the streaming response has timed out, or was canceled. We will send the remaining response as a text message once completed."
+            )
+            typing_indicator.start()
+        return streaming_response_ended and previously_detected_streaming_ended
+
     # TODO: https://cookbook.openai.com/examples/how_to_handle_rate_limits
     async def stream_response(
         self, input: str, context: TurnContext, last_response_id: str | None = None
@@ -145,18 +180,37 @@ class RootAgent:
             previous_response_id=last_response_id,
         )
 
+        # Check if the streaming response has ended
+        streaming_response_ended = False
+        typing_indicator = TypingIndicator(context, interval_seconds=0.1)
+
         # Return the streamed response
         response = ""
+        response_remaining = ""
         try:
             async for event in result.stream_events():
                 if event.type == "raw_response_event" and isinstance(
                     event.data, ResponseTextDeltaEvent
                 ):
-                    context.streaming_response.queue_text_chunk(event.data.delta)
+                    streaming_response_ended = await self._check_streaming_has_ended(
+                        context=context,
+                        typing_indicator=typing_indicator,
+                        previously_detected_streaming_ended=streaming_response_ended,
+                    )
+                    if not streaming_response_ended:
+                        context.streaming_response.queue_text_chunk(event.data.delta)
+                    else:
+                        response_remaining += event.data.delta
                     response += event.data.delta
         except Exception as e:
             logger.error(f"Error streaming agent response: {e}", exc_info=True)
             raise e
+
+        # Stop the typing indicator if it was started
+        if streaming_response_ended:
+            typing_indicator.stop()
+            if response_remaining:
+                await context.send_activity(response_remaining)
 
         # Track consumed tokens
         usage = result.context_wrapper.usage

--- a/code/copilot/app/agents/root.py
+++ b/code/copilot/app/agents/root.py
@@ -140,19 +140,19 @@ class RootAgent:
         :type previously_detected_streaming_ended: bool
         """
         streaming_response_ended = (
-            context.streaming_response._ended or context.streaming_response._canceled
+            context.streaming_response._ended or context.streaming_response._cancelled
         )
         if streaming_response_ended and not previously_detected_streaming_ended:
             logger.warning(
-                "The streaming response has already ended or was canceled.",
+                "The streaming response has already ended or was cancelled.",
                 extra={
-                    "code": "STREAMING_RESPONSE_ENDED_OR_CANCELED",
+                    "code": "STREAMING_RESPONSE_ENDED_OR_CANCELLED",
                     "streaming_response_ended": context.streaming_response._ended,
-                    "streaming_response_canceled": context.streaming_response._canceled,
+                    "streaming_response_cancelled": context.streaming_response._cancelled,
                 },
             )
             await context.send_activity(
-                "It was detected that the streaming response has timed out, or was canceled. We will send the remaining response as a text message once completed."
+                "It was detected that the streaming response has timed out, or was cancelled. We will send the remaining response as a text message once completed."
             )
             typing_indicator.start()
         return streaming_response_ended and previously_detected_streaming_ended

--- a/code/copilot/app/copilot/common.py
+++ b/code/copilot/app/copilot/common.py
@@ -184,11 +184,22 @@ async def stream_string_in_chunks(context: TurnContext, text: str):
     :param text: The text which must be streamed.
     :type text: str
     """
-    # Split string into words
-    words = text.split(sep=" ")
-    for word in words:
-        # Stream each word as a chunk
-        context.streaming_response.queue_text_chunk(f"{word} ")
+    if context.streaming_response._ended or context.streaming_response._canceled:
+        logger.warning(
+            "Attempted to stream response, but the streaming response has already ended or was canceled.",
+            extra={
+                "code": "STREAMING_RESPONSE_ENDED_OR_CANCELED",
+                "streaming_response_ended": context.streaming_response._ended,
+                "streaming_response_canceled": context.streaming_response._canceled,
+            },
+        )
+        await context.send_activity(text)
+    else:
+        # Split string into words
+        words = text.split(sep=" ")
+        for word in words:
+            # Stream each word as a chunk
+            context.streaming_response.queue_text_chunk(f"{word} ")
 
-        # Simulate delay for streaming effect
-        await asyncio.sleep(0.1)
+            # Simulate delay for streaming effect
+            await asyncio.sleep(0.1)

--- a/code/copilot/app/copilot/common.py
+++ b/code/copilot/app/copilot/common.py
@@ -184,13 +184,13 @@ async def stream_string_in_chunks(context: TurnContext, text: str):
     :param text: The text which must be streamed.
     :type text: str
     """
-    if context.streaming_response._ended or context.streaming_response._canceled:
+    if context.streaming_response._ended or context.streaming_response._cancelled:
         logger.warning(
-            "Attempted to stream response, but the streaming response has already ended or was canceled.",
+            "Attempted to stream response, but the streaming response has already ended or was cancelled.",
             extra={
-                "code": "STREAMING_RESPONSE_ENDED_OR_CANCELED",
+                "code": "STREAMING_RESPONSE_ENDED_OR_CANCELLED",
                 "streaming_response_ended": context.streaming_response._ended,
-                "streaming_response_canceled": context.streaming_response._canceled,
+                "streaming_response_cancelled": context.streaming_response._cancelled,
             },
         )
         await context.send_activity(text)

--- a/code/copilot/app/copilot/handler_msteams.py
+++ b/code/copilot/app/copilot/handler_msteams.py
@@ -219,7 +219,7 @@ class MSTeamsHandler(AbstractHandler):
                         data=cleaned_data,
                     )
                 )
-                processed_attachment_names.append(attachment.name)
+                processed_attachment_names.append(f"`{attachment.name}`")
 
             # Add info about files in context
             logger.info(

--- a/code/copilot/app/copilot/handler_webchat.py
+++ b/code/copilot/app/copilot/handler_webchat.py
@@ -216,7 +216,7 @@ class WebchatHandler(AbstractHandler):
                         data=cleaned_data,
                     )
                 )
-                processed_attachment_names.append(attachment.name)
+                processed_attachment_names.append(f"`{attachment.name}`")
 
             # Add info about files in context
             logger.info(


### PR DESCRIPTION
**Proposed changes**:
- Handle sceanrios where the streaming response has ended.
- Send the remaining text sing batches and inform the user about it.
